### PR TITLE
feat: Bump to v2.

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: packettoobig
 name: peering
-version: 1.0.5
+version: 2.0.0
 readme: README.md
 authors:
     - Eliott T  <contact@packettoobig.net>

--- a/plugins/modules/peeringdb_getasn.py
+++ b/plugins/modules/peeringdb_getasn.py
@@ -21,7 +21,7 @@ short_description: Searches for ASN policies and interfaces
 version_added: "2.0.0"
 
 description:
-    - "This modules encapsules peeringDB API to search for an specific ASN interfaces and policy information"
+    - "This modules encapsules peeringDB API to search for specific ASN interfaces and policy information"
 
 options:
     asn_list:
@@ -38,7 +38,7 @@ options:
         required: false
     ix_name:
         description:
-          - "The peerigDB IXP Name"
+          - "The peeringDB IXP Name"
         required: false
 '''
 
@@ -91,14 +91,17 @@ def getASNData(asn_list, api_key=None):
     return data_objects
 
 def parseSingularASNData(asn, data, ixId=None, ixName=None):
-    netfields = ["name",
-              "info_prefixes4",
-              "info_prefixes6",
-              "poc_set",
-              "info_unicast",
-              "info_ipv6"]
+    netfields = [
+                "name",
+                "info_prefixes4",
+                "info_prefixes6",
+                "poc_set",
+                "info_unicast",
+                "info_ipv6"
+                ]
 
-    ixfields = ["name",
+    ixfields = [
+                "name",
                 "ix_id",
                 "ipaddr4",
                 "ipaddr6",

--- a/plugins/modules/peeringdb_getasn.py
+++ b/plugins/modules/peeringdb_getasn.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 #  Heavily inspired from https://github.com/renatoalmeidaoliveira/netero/tree/master/plugins/modules/peeringdb_getasn.py
 #  Stole the fix from https://gitlab.xs4me.net/jorg/netero/-/commit/129209c5302b81fe16c1887508f8e56b7a88bc73
 #  Modified for API key support
@@ -11,30 +13,25 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 
-ANSIBLE_METADATA = {
-    'metadata_version': '1.0.1',
-    'status': ['preview'],
-    'supported_by': 'community'
-}
 DOCUMENTATION = '''
 module: peeringdb_getasn
 
-short_description: Searches for an ASN policy and interfaces
+short_description: Searches for ASN policies and interfaces
 
-version_added: "0.0.1"
+version_added: "2.0.0"
 
 description:
-    - "This modules encapsules peeringDB API to search for an specific ASN his interfaces and policy information"
+    - "This modules encapsules peeringDB API to search for an specific ASN interfaces and policy information"
 
 options:
-    asn:
+    asn_list:
         description:
-          - "The searched ASN"
+          - "The searched list of ASNs"
         required: true
     api_key:
         description:
           - "Your peeringDB API key"
-        required: false
+        required: true
     ix_id:
         description:
           - "The peeringDB IXP ID"
@@ -46,9 +43,11 @@ options:
 '''
 
 EXAMPLES = '''
-- name: Search ASN 64497
+- name: Search ASN 64497,65500
   peeringdb_getasn:
-    asn: 64497
+    asn_list:
+      - 64497
+      - 65500
     ix_id: 70
 '''
 
@@ -62,64 +61,57 @@ object:
 # Implement retries and backoff because of the peeringdb ratelimiting
 # Documentation here : https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html
 retry_strategy = urllib3.util.Retry(
-    total=100, # Default 10
-    backoff_factor=0.05, # Default 0
+    total=10, # Default 10
+    backoff_factor=0.2, # Default 0
     allowed_methods=["HEAD", "GET", "OPTIONS"],
     status_forcelist=[413, 429, 500, 502, 503, 504]
 )
 http = requests.Session()
 http.mount("https://", requests.adapters.HTTPAdapter(max_retries=retry_strategy))
 
-def getASNID(asn, api_key=None):
-    if (api_key is not None):
-        headers = {"AUTHORIZATION": "Api-Key " + api_key}
-        request = http.get("https://www.peeringdb.com/api/net?asn=" + str(asn),
-                               headers=headers)
-    else:
-        request = http.get(
-            "https://www.peeringdb.com/api/net?asn=" + str(asn))
-
-    request.raise_for_status()
-    response = json.loads(request.text)
-    result = None
-    for data in response["data"]:
-        if data["asn"] == int(asn):
-            result = data["id"]
-            break
-    if result is not None:
-        return result
-    else:
-        raise NameError('Unknown ASN')
-
-
-def getASNData(asn, api_key=None):
-
-    asnId = getASNID(asn)
+def getASNData(asn_list, api_key=None):
+    if len(asn_list) > 150:
+        raise NameError("Maximum 150 objects in a single request,\
+            see https://docs.peeringdb.com/howto/work_within_peeringdbs_query_limits/")
 
     if (api_key is not None):
-        asnId = getASNID(asn, api_key)
-        headers = {"AUTHORIZATION": "Api-Key " + api_key}
-        request = http.get("https://www.peeringdb.com/api/net/" + str(asnId),
-                               headers=headers)
+        headers = {
+            "Authorization": "Api-Key " + api_key,
+            "User-Agent": "Ansible module: packettoobig.peering.peeringdb_getasn"
+        }
     else:
-        asnId = getASNID(asn)
-        request = http.get(
-            "https://www.peeringdb.com/api/net/" + str(asnId))
-
+        raise NameError("Please provide an API key or you will hit the rate limits,\
+            see https://docs.peeringdb.com/howto/work_within_peeringdbs_query_limits/")
+    request = http.get("https://www.peeringdb.com/api/net?depth=2&asn__in=" + ','.join(map(str, asn_list)), headers=headers)
     request.raise_for_status()
     response = json.loads(request.text)
-    return response["data"][0]
+    data_objects = response.get("data", [])
+    if len(data_objects) != len(asn_list):
+        raise NameError("No data for one or more ASN IDs in the request.")
+    return data_objects
 
+def parseSingularASNData(asn, data, ixId=None, ixName=None):
+    netfields = ["name",
+              "info_prefixes4",
+              "info_prefixes6",
+              "poc_set",
+              "info_unicast",
+              "info_ipv6"]
 
-def parseASNData(asn, api_key=None, ixId=None, ixName=None):
-    keys = ["info_prefixes4", "info_prefixes6",
-            "poc_set", "info_unicast", "info_ipv6"]
-    data = getASNData(asn, api_key)
+    ixfields = ["name",
+                "ix_id",
+                "ipaddr4",
+                "ipaddr6",
+                "speed",
+                "bfd_support",
+                "is_rs_peer"
+                ]
+
     output = {}
     ixOutput = []
     irrData = []
     output["asn"] = asn
-    for key in keys:
+    for key in netfields:
         if key in data:
             output[key] = data[key]
     if "irr_as_set" in data:
@@ -145,34 +137,38 @@ def parseASNData(asn, api_key=None, ixId=None, ixName=None):
             ixOutput = []
             for ix in ixSet:
                 interfaceData = {}
-                if ix[ixFilter] == inputIxData:
+                if str(ix[ixFilter]) == str(inputIxData):
                     if "operational" in ix and ix["operational"]:
-                        if "ipaddr4" in ix:
-                            interfaceData["ipaddr4"] = ix["ipaddr4"]
-                        if "ipaddr6" in ix:
-                            interfaceData["ipaddr6"] = ix["ipaddr6"]
-                        if "speed" in ix:
-                            interfaceData["speed"] = ix["speed"]
+                        for key in ixfields:
+                            if key in ix:
+                                interfaceData[key] = ix[key]
                     ixOutput.append(interfaceData)
     if ixOutput != []:
         output["interfaces"] = ixOutput
     output["irr_as_set"] = irrData
     return output
 
+def parseAllASNDataAtOnce(asn_list, api_key=None, ixId=None, ixName=None):
+    data_objects = getASNData(asn_list, api_key)
+    # Need to sort data_objects similarly to asn_list
+    sorted_data_objects = sorted(data_objects, key=lambda data: asn_list.index(data["asn"]))
+    # Pair up the asn_list and the sorted data objects
+    paired_data = zip(asn_list, sorted_data_objects)
+    # Process the paired data
+    res = [parseSingularASNData(pair[0], pair[1], ixId, ixName) for pair in paired_data]
+    return res
 
 def main():
-
     fields = {
-        "asn":       {"required": True,  "type": "int"},
-        "api_key":  {"required": False, "type": "str", "no_log": True},
+        "asn_list": {"required": True,  "type": "list", "elements": "int"},
+        "api_key":  {"required": True, "type": "str", "no_log": True},
         "ix_id":     {"required": False, "type": "int"},
         "ix_name":   {"required": False, "type": "str"}
     }
     module = AnsibleModule(argument_spec=fields)
-    response = parseASNData(module.params['asn'], module.params['api_key'],
-                             module.params['ix_id'], module.params['ix_name'])
+    response = parseAllASNDataAtOnce(module.params['asn_list'], module.params['api_key'],
+                             str(module.params['ix_id']), str(module.params['ix_name']))
     module.exit_json(changed=False, message=response)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
* fix: Optimize peeringdb API queries (a single query needed instead of dozens in v1).
* feat: Add "ixfields" var.

BREAKING CHANGES:
* `asn` now needs to be an `asn_list` ("list" type instead of str)
* `api_key` is now mandatory (for single large queries)
* The returned data format is different: the playbooks and role need to be adapted