### PR TITLE
fix: Respect ansible best practices

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: packettoobig
 name: peering
-version: 2.1.0
+version: 2.2.0
 readme: README.md
 authors:
     - Eliott T  <contact@packettoobig.net>

--- a/plugins/modules/irr_prefix.py
+++ b/plugins/modules/irr_prefix.py
@@ -1,4 +1,6 @@
-#! /usr/bin/env python3
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
 #  Heavily inspired from https://github.com/renatoalmeidaoliveira/netero/tree/master/plugins/modules/irr_prefix.py
 #  Modified quite a lot
 #  Huge thanks to Renato Almeida de Oliveira for the base

--- a/plugins/modules/peeringdb_getasn.py
+++ b/plugins/modules/peeringdb_getasn.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 #  Heavily inspired from https://github.com/renatoalmeidaoliveira/netero/tree/master/plugins/modules/peeringdb_getasn.py


### PR DESCRIPTION
Still force python3 use though

Link to documentation: https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#id6